### PR TITLE
Better Image Sanitization and Subscribe

### DIFF
--- a/lib/mako/article.rb
+++ b/lib/mako/article.rb
@@ -2,13 +2,13 @@
 
 module Mako
   class Article
-    attr_reader :title, :published, :summary, :url
+    attr_reader :title, :published, :summary, :uri
 
     def initialize(args)
       @title = args.fetch(:title, '')
       @published = args.fetch(:published)
+      @uri = URI.parse(args.fetch(:url))
       @summary = sanitize(args.fetch(:summary))
-      @url = args.fetch(:url)
     end
 
     # Converts published Time object to formatted string
@@ -18,17 +18,29 @@ module Mako
       @published.strftime('%A, %d %B %Y at %I:%M %P')
     end
 
+    # Converts URI object into string
+    #
+    # @return [String]
+    def url
+      uri.to_s
+    end
+
     private
 
-    # @private
-    # Removes img tags (if configured) and transforms h1 tags into
-    # p tags with the class bold
+    # Transforms img tags into a tags (if configured) and transforms h1 tags
+    # into p tags with the class bold
     #
     # @param [String] html an html document string
     # @return [String] a sanitized html document string
     def sanitize(html)
       doc = Nokogiri::HTML::DocumentFragment.parse(html)
-      doc.css('img').each(&:remove) if Mako.config.sanitize_images
+      if Mako.config.sanitize_images
+        doc.css('img').each do |n|
+          n.name = 'a'
+          n.content = "📷 #{n['alt']}" || '📷 Image'
+          n['href'] = URI.parse(n['src']).absolutize!(uri)
+        end
+      end
       doc.css('h1,h2,h3,h4,h5,h6').each { |n| n.name = 'p'; n.set_attribute('class', 'bold') }
       doc.to_s
     end

--- a/lib/mako/commands/subscribe.rb
+++ b/lib/mako/commands/subscribe.rb
@@ -9,6 +9,7 @@ module Mako
       end
       feeds = Mako::FeedFinder.new(uris: args).find
       write_to_subscriptions(feeds)
+      Mako.logger.info "Subscribed to the following feeds: #{feeds}"
     end
 
     def self.write_to_subscriptions(feed_urls)

--- a/lib/mako/core.rb
+++ b/lib/mako/core.rb
@@ -49,7 +49,6 @@ module Mako
 
     private
 
-    # @private
     # Prints configuration file, source, and destination directory to STDOUT.
     def log_configuration_information
       Mako.logger.info "Configuration File: #{Mako.config.config_file}"

--- a/lib/mako/core_ext.rb
+++ b/lib/mako/core_ext.rb
@@ -2,3 +2,4 @@
 
 require_relative 'core_ext/numeric'
 require_relative 'core_ext/time'
+require_relative 'core_ext/uri'

--- a/lib/mako/core_ext/uri.rb
+++ b/lib/mako/core_ext/uri.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module URI
+  class Generic
+    # Compares parsed URI with a base URI and adds the host section, if needed
+    #
+    # @param base_uri [URI]
+    def absolutize!(base_uri)
+      base_uri.host == host ? to_s : base_uri.merge(self).to_s
+    end
+  end
+end

--- a/lib/mako/feed_constructor.rb
+++ b/lib/mako/feed_constructor.rb
@@ -23,7 +23,6 @@ module Mako
 
     private
 
-    # @private
     # Takes raw XML and parses it into a Feedjira::Feed object
     #
     # @return [Feedjira::Feed]

--- a/lib/mako/feed_finder.rb
+++ b/lib/mako/feed_finder.rb
@@ -30,7 +30,10 @@ module Mako
         else
           html = Nokogiri::HTML(request[:body])
           potential_feed_uris = html.xpath(XPATHS.detect { |path| !html.xpath(path).empty? })
-          next if potential_feed_uris.empty?
+          if potential_feed_uris.empty?
+            Mako.errors.add_error "Could not find feed for #{request[:uri]}"
+            next
+          end
           uri_string = potential_feed_uris.first.value
           feed_uri = URI.parse(uri_string)
           feed_uri.absolutize!(request[:uri])

--- a/lib/mako/feed_finder.rb
+++ b/lib/mako/feed_finder.rb
@@ -33,11 +33,7 @@ module Mako
           next if potential_feed_uris.empty?
           uri_string = potential_feed_uris.first.value
           feed_uri = URI.parse(uri_string)
-          if request[:uri].host == feed_uri.host
-            feed_uri.to_s
-          else
-            request[:uri].merge(feed_uri).to_s
-          end
+          feed_uri.absolutize!(request[:uri])
         end
       end.compact
     end

--- a/lib/mako/feed_finder.rb
+++ b/lib/mako/feed_finder.rb
@@ -43,7 +43,6 @@ module Mako
 
     private
 
-    # @private
     # Make requests for each URI passed in and return an array of hashes
     # with either just the URI (in the case that the URI passed in was already
     # a feed URI), or the URI and the response body.

--- a/lib/mako/subscription_list_writer.rb
+++ b/lib/mako/subscription_list_writer.rb
@@ -22,7 +22,6 @@ module Mako
 
     private
 
-    # @private
     # Returns the rendered string for the correct file type.
     #
     # @return [String]

--- a/test/mako/article_test.rb
+++ b/test/mako/article_test.rb
@@ -9,7 +9,7 @@ class ArticleTest < Minitest::Test
                                    published: Time.now,
                                    summary: "<h1>Hello</h1> \n <p>This is an article</p> <img src='example'>",
                                    url: 'http://example.com')
-      assert_equal "<p class=\"bold\">Hello</p> \n <p>This is an article</p> ", @article.summary
+      assert_equal "<p class=\"bold\">Hello</p> \n <p>This is an article</p> <a src=\"example\" href=\"http://example.com/example\">📷 </a>", @article.summary
     end
   end
 


### PR DESCRIPTION
**Image Sanitization**

If configured (`sanitize_images: true`), images are replaced with an `a` tag that links to the image, and has either the `alt` or `Image` as the text. 

**Subscribe**

As per #6, `mako subscribe` has better messaging around success and failure. 